### PR TITLE
Security mitigation

### DIFF
--- a/smart-contracts/main/contracts/Retriev.sol
+++ b/smart-contracts/main/contracts/Retriev.sol
@@ -500,9 +500,10 @@ contract Retriev is ERC721, Ownable, ReentrancyGuard {
         require(!deals[deal_index].canceled, "Deal canceled yet");
         // KS-PLW-03: Client can cancel the deal after it is accepted
         require(
-            deals[deal_index].timestamp_start == 0,
+            block.timestamp >(deals[deal_index].timestamp_start + deals[deal_index].duration),
             "Deal Accepted already, cannot be cancelled"
         );
+
         deals[deal_index].canceled = true;
         deals[deal_index].timestamp_start = 0;
         // Remove funds from internal vault giving back to user
@@ -575,6 +576,8 @@ contract Retriev is ERC721, Ownable, ReentrancyGuard {
             getRound(active_appeals[deals[deal_index].data_uri]) >= 99,
             "Found an active appeal, can't redeem"
         );
+        // KS-PLW-04: Dealer can claim bounty when deal is cancelled
+        require(!deals[deal_index].canceled, "Deal already cancelled");
 
         // Move value from contract to address
         vault[address(this)] -= deals[deal_index].value;

--- a/smart-contracts/main/contracts/Retriev.sol
+++ b/smart-contracts/main/contracts/Retriev.sol
@@ -396,6 +396,8 @@ contract Retriev is ERC721, Ownable, ReentrancyGuard {
         } else {
             for (uint256 i = 0; i < active_providers.length; i++) {
                 if (active_providers[i] == _provider) {
+                    // KS-PLW-07: Vault Deposit Not Returned to Outgoing Provider
+                    require(vault[_provider] == 0, "Provider Vault is not empty");
                     delete active_providers[i];
                 }
             }

--- a/smart-contracts/main/contracts/Retriev.sol
+++ b/smart-contracts/main/contracts/Retriev.sol
@@ -498,9 +498,10 @@ contract Retriev is ERC721, Ownable, ReentrancyGuard {
             "Only owner can cancel the deal"
         );
         require(!deals[deal_index].canceled, "Deal canceled yet");
+        // KS-PLW-03: Client can cancel the deal after it is accepted
         require(
             deals[deal_index].timestamp_start == 0,
-            "Deal was accepted, can't cancel"
+            "Deal Accepted already, cannot be cancelled"
         );
         deals[deal_index].canceled = true;
         deals[deal_index].timestamp_start = 0;

--- a/smart-contracts/main/contracts/Retriev.sol
+++ b/smart-contracts/main/contracts/Retriev.sol
@@ -29,6 +29,7 @@ contract Retriev is ERC721, Ownable, ReentrancyGuard {
     struct Provider {
         bool active;
         string endpoint;
+        bool _exists;
     }
 
     // Defining deal struct
@@ -316,6 +317,13 @@ contract Retriev is ERC721, Ownable, ReentrancyGuard {
     }
 
     /*
+        This method will say if address is a provider or not
+    */
+    function providerExists(address check) public view returns (bool) {
+        return providers[check]._exists;
+    }
+
+    /*
         This method will allow owner to enable or disable a referee
     */
     function setRefereeStatus(
@@ -337,6 +345,15 @@ contract Retriev is ERC721, Ownable, ReentrancyGuard {
     }
 
     /*
+        This method will allow owner to remove a provider
+    */
+    function removeProvider(
+        address _provider
+    ) external onlyOwner() {
+        delete providers[_provider];
+    }
+
+    /*
         This method will allow owner to enable or disable a provider
     */
     function setProviderStatus(
@@ -344,6 +361,10 @@ contract Retriev is ERC721, Ownable, ReentrancyGuard {
         bool _state,
         string memory _endpoint
     ) external {
+        // KS-PLW-02: Duplicate provider address is allowed
+        require(_provider != address(0x0), "Invalid address");
+        require(providers[_provider]._exists == false, "Provider already exists");
+        providers[_provider]._exists = true;
         if (permissioned_providers) {
             require(msg.sender == owner(), "Only owner can manage providers");
         } else {

--- a/smart-contracts/main/contracts/Retriev.sol
+++ b/smart-contracts/main/contracts/Retriev.sol
@@ -331,6 +331,8 @@ contract Retriev is ERC721, Ownable, ReentrancyGuard {
         bool _state,
         string memory _endpoint
     ) external onlyOwner {
+        // KS-PLW-05: Duplicate referee address is allowed
+        require(!isReferee(_referee), "Duplicate referees are not permitted");
         referees[_referee].active = _state;
         referees[_referee].endpoint = _endpoint;
         if (_state) {

--- a/smart-contracts/main/contracts/Retriev.sol
+++ b/smart-contracts/main/contracts/Retriev.sol
@@ -650,6 +650,23 @@ contract Retriev is ERC721, Ownable, ReentrancyGuard {
     }
 
     /*
+        This method checks for duplicate signatures
+    */
+    function checkDuplicate(bytes[] memory _arr) internal pure returns (bool) {
+        if (_arr.length == 0) {
+            return false;
+        }
+        for (uint256 i = 0; i < _arr.length - 1; i++) {
+            for (uint256 j = i + 1; j < _arr.length; j++) {
+                if (sha256(_arr[i]) == sha256(_arr[j])) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /*
         This method will allow referees to process an appeal
     */
     function processAppeal(
@@ -659,6 +676,8 @@ contract Retriev is ERC721, Ownable, ReentrancyGuard {
     ) external {
         uint256 appeal_index = active_appeals[deals[deal_index].data_uri];
         uint256 round = getRound(appeal_index);
+        // KS-PLW-01: Duplicate Signatures are not checked while processing an appeal
+        require(!checkDuplicate(_signatures), "processAppeal: Duplicate signatures");
         require(deals[deal_index].timestamp_start > 0, "Deal is not active");
         require(appeals[appeal_index].active, "Appeal is not active");
         require(

--- a/smart-contracts/main/foundry/Retriev.t.sol
+++ b/smart-contracts/main/foundry/Retriev.t.sol
@@ -174,6 +174,40 @@ contract RetrievTest is Test {
         );
     }
 
+    // CREATE DEAL WITHOUT PROPOSAL
+    function testCreateDealAndCancelPrematurely() public {
+        address provider = vm.addr(5);
+        address client = vm.addr(6);
+        vm.deal(provider, 100 ether);
+        retriev.setProviderStatus(
+            provider,
+            true,
+            "http://localhost:8000"
+        );
+        assertEq(
+            retriev.isProvider(provider),
+            true
+        );
+        // Start making calls with provider's key
+        vm.startPrank(provider);
+        uint256 duration = retriev.min_duration();
+        uint256 collateral = 1 wei;
+        address[] memory appeal_addresses = new address[](1);
+        appeal_addresses[0] = provider;
+        retriev.createDeal{value: collateral}(
+            client,
+            "ipfs://QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG",
+            duration,
+            appeal_addresses
+        );
+        vm.stopPrank();
+
+        vm.startPrank(client);
+        // try to cancel prematurely
+        vm.expectRevert("Deal Accepted already, cannot be cancelled");
+        retriev.cancelDealProposal(1);
+    }
+
     // CREATE DEAL WITHOUT PROPOSAL AND ACCEPT
     function testCreateDealAndAppeal() public {
         address provider = vm.addr(5);

--- a/smart-contracts/main/foundry/Retriev.t.sol
+++ b/smart-contracts/main/foundry/Retriev.t.sol
@@ -66,6 +66,21 @@ contract RetrievTest is Test {
             "http://localhost:7002"
         );
     }
+    
+    function testAddDuplicateReferees() public {
+        address referee1 = vm.addr(6);
+        retriev.setRefereeStatus(
+            referee1,
+            true,
+            "http://localhost:7000"
+        );
+        vm.expectRevert("Duplicate referees are not permitted");
+        retriev.setRefereeStatus(
+            referee1,
+            true,
+            "http://localhost:7001"
+        );
+    }
 
     // CREATE DEAL PROPOSAL
     function testCreateDealProposal() public {

--- a/smart-contracts/main/foundry/Retriev.t.sol
+++ b/smart-contracts/main/foundry/Retriev.t.sol
@@ -82,6 +82,27 @@ contract RetrievTest is Test {
         );
     }
 
+    function testRefereeSafeDelete() public {
+        address referee1 = vm.addr(6);
+        retriev.setRefereeStatus(
+            referee1,
+            true,
+            "http://localhost:7000"
+        );
+        retriev.setRefereeStatus(
+            referee1,
+            false,
+            "http://localhost:7001"
+        );
+        vm.expectRevert("Duplicate referees are not permitted");
+        retriev.setRefereeStatus(
+            referee1,
+            true,
+            "http://localhost:7001"
+        );
+       
+    }
+
     // CREATE DEAL PROPOSAL
     function testCreateDealProposal() public {
         address provider = vm.addr(5);

--- a/smart-contracts/main/foundry/Retriev.t.sol
+++ b/smart-contracts/main/foundry/Retriev.t.sol
@@ -12,6 +12,26 @@ contract RetrievTest is Test {
         retriev = new Retriev(address(this));
     }
 
+    function testAddSameProviderTwice() public {
+        address provider = vm.addr(5);
+        retriev.setProviderStatus(
+            provider,
+            true,
+            "http://localhost:8000"
+        );
+
+        // expect an error
+        vm.expectRevert("Provider already exists");
+        retriev.setProviderStatus(
+            provider,
+            true,
+            "http://localhost:8000"
+        );
+        
+        // cleanup
+        retriev.removeProvider(provider);
+    }
+
     // SETUP NETWORK
     function testAddProvider() public {
         address provider = vm.addr(5);


### PR DESCRIPTION
This branch addresses security mitigations for the following findings, outlined in `Secure Code Review: Findings and Recommendations Report v1.0`, Kudelski Security Inc.:

- KS-PLW-01 – Duplicate Signatures are not checked while processing an appeal
- KS-PLW-02 – Duplicate provider address is allowed
- KS-PLW-03 – Client can cancel the deal after it is accepted
- KS-PLW-04 – Dealer can claim bounty when deal is cancelled
- KS-PLW-05 – Duplicate referee address is allowed
- KS-PLW-06 – Removal of referee adds null address to array index
- KS-PLW-07 – Vault Deposit Not Returned to Outgoing Provider